### PR TITLE
feat(core): enforce URL allowlist for downloads

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")

--- a/src/main/kotlin/com/download/downloaderbot/core/cache/AsyncRedisMediaCache.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/cache/AsyncRedisMediaCache.kt
@@ -1,6 +1,5 @@
 package com.download.downloaderbot.core.cache
 
-import com.download.downloaderbot.core.cache.util.UrlNormalizer
 import com.download.downloaderbot.core.domain.Media
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import org.springframework.data.redis.core.ReactiveRedisTemplate
@@ -12,7 +11,7 @@ class AsyncRedisMediaCache(
     private val mediaTemplate: ReactiveRedisTemplate<String, List<Media>>
 ) : MediaCache {
 
-    private fun key(url: String) = "media:url:${UrlNormalizer.normalize(url)}"
+    private fun key(url: String) = "media:url:$url"
 
     override suspend fun get(sourceUrl: String): List<Media>? =
         mediaTemplate.opsForValue()

--- a/src/main/kotlin/com/download/downloaderbot/core/config/OkHttpConfig.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/config/OkHttpConfig.kt
@@ -1,0 +1,18 @@
+package com.download.downloaderbot.core.config
+
+import okhttp3.OkHttpClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+@Configuration
+class OkHttpConfig {
+
+    @Bean
+    fun okHttpClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .followRedirects(true)
+            .followSslRedirects(true)
+            .callTimeout(Duration.ofSeconds(20))
+            .build()
+}

--- a/src/main/kotlin/com/download/downloaderbot/core/config/properties/SourceAllowProperties.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/config/properties/SourceAllowProperties.kt
@@ -1,0 +1,8 @@
+package com.download.downloaderbot.core.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "downloader.sources")
+data class SourceAllowProperties(
+    val allow: List<String> = emptyList()
+)

--- a/src/main/kotlin/com/download/downloaderbot/core/lock/RedisUrlLock.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/lock/RedisUrlLock.kt
@@ -1,6 +1,5 @@
 package com.download.downloaderbot.core.lock
 
-import com.download.downloaderbot.core.cache.util.UrlNormalizer
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
@@ -15,7 +14,7 @@ class RedisUrlLock(
     private val redis: ReactiveStringRedisTemplate
 ) : UrlLockManager {
 
-    private fun key(url: String) = "lock:url:${UrlNormalizer.normalize(url)}"
+    private fun key(url: String) = "lock:url:$url"
 
     override suspend fun tryAcquire(url: String, ttl: Duration): String? {
         val token = UUID.randomUUID().toString()

--- a/src/main/kotlin/com/download/downloaderbot/core/net/UrlNormalizer.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/net/UrlNormalizer.kt
@@ -1,11 +1,13 @@
-package com.download.downloaderbot.core.cache.util
+package com.download.downloaderbot.core.net
 
+import org.springframework.stereotype.Component
 import java.net.URI
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-object UrlNormalizer {
+@Component
+class UrlNormalizer {
     private val DROP_EXACT = setOf("fbclid", "gclid", "msclkid", "dclid", "igshid")
     private fun isNoise(name: String) =
         name.startsWith("utm_", ignoreCase = true) || name.lowercase() in DROP_EXACT

--- a/src/main/kotlin/com/download/downloaderbot/core/net/UrlResolver.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/net/UrlResolver.kt
@@ -1,0 +1,21 @@
+package com.download.downloaderbot.core.net
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.springframework.stereotype.Component
+
+@Component
+class UrlResolver(private val client: OkHttpClient) {
+    fun finalUrl(url: String): String {
+        val req = Request.Builder()
+            .url(url)
+            .get()
+            .header("User-Agent", "Mozilla/5.0")
+            .build()
+        client.newCall(req)
+            .execute()
+            .use { resp ->
+            return resp.request.url.toString()
+        }
+    }
+}

--- a/src/main/kotlin/com/download/downloaderbot/core/security/UrlAllowlist.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/security/UrlAllowlist.kt
@@ -1,0 +1,13 @@
+package com.download.downloaderbot.core.security
+
+import com.download.downloaderbot.core.config.properties.SourceAllowProperties
+import org.springframework.stereotype.Component
+
+@Component
+class UrlAllowlist(
+    private val props: SourceAllowProperties
+) {
+    private val patterns = props.allow.map { it.toRegex(RegexOption.IGNORE_CASE) }
+
+    fun isAllowed(url: String): Boolean = patterns.any { it.containsMatchIn(url) }
+}

--- a/src/main/kotlin/com/download/downloaderbot/core/service/CachedMediaDownloadService.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/service/CachedMediaDownloadService.kt
@@ -5,8 +5,10 @@ import com.download.downloaderbot.core.net.UrlNormalizer
 import com.download.downloaderbot.core.config.properties.CacheProperties
 import com.download.downloaderbot.core.domain.Media
 import com.download.downloaderbot.core.downloader.DownloadInProgressException
+import com.download.downloaderbot.core.downloader.UnsupportedSourceException
 import com.download.downloaderbot.core.lock.UrlLockManager
 import com.download.downloaderbot.core.net.UrlResolver
+import com.download.downloaderbot.core.security.UrlAllowlist
 import kotlinx.coroutines.delay
 import mu.KotlinLogging
 import org.springframework.context.annotation.Primary
@@ -22,12 +24,16 @@ class CachedMediaDownloadService(
     private val props: CacheProperties,
     private val urlLock: UrlLockManager,
     private val urlResolver: UrlResolver,
-    private val urlNormalizer: UrlNormalizer
+    private val urlNormalizer: UrlNormalizer,
+    private val allowlist: UrlAllowlist
 ) : MediaDownloadService {
 
     override suspend fun download(url: String): List<Media> {
         val resolvedUrl = urlResolver.finalUrl(url)
         val normalizedUrl = urlNormalizer.normalize(resolvedUrl)
+
+        if (!allowlist.isAllowed(normalizedUrl))
+            throw UnsupportedSourceException(normalizedUrl)
 
         getCachedOrNull(normalizedUrl)?.let { return it }
 

--- a/src/main/kotlin/com/download/downloaderbot/core/service/CachedMediaDownloadService.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/service/CachedMediaDownloadService.kt
@@ -1,15 +1,16 @@
 package com.download.downloaderbot.core.service
 
 import com.download.downloaderbot.core.cache.MediaCache
+import com.download.downloaderbot.core.net.UrlNormalizer
 import com.download.downloaderbot.core.config.properties.CacheProperties
 import com.download.downloaderbot.core.domain.Media
 import com.download.downloaderbot.core.downloader.DownloadInProgressException
 import com.download.downloaderbot.core.lock.UrlLockManager
+import com.download.downloaderbot.core.net.UrlResolver
 import kotlinx.coroutines.delay
 import mu.KotlinLogging
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
-import java.time.Duration
 
 private val log = KotlinLogging.logger {}
 
@@ -20,25 +21,30 @@ class CachedMediaDownloadService(
     private val mediaCache: MediaCache,
     private val props: CacheProperties,
     private val urlLock: UrlLockManager,
+    private val urlResolver: UrlResolver,
+    private val urlNormalizer: UrlNormalizer
 ) : MediaDownloadService {
 
     override suspend fun download(url: String): List<Media> {
-        getCachedOrNull(url)?.let { return it }
+        val resolvedUrl = urlResolver.finalUrl(url)
+        val normalizedUrl = urlNormalizer.normalize(resolvedUrl)
 
-        var token = urlLock.tryAcquire(url, props.lockTtl)
+        getCachedOrNull(normalizedUrl)?.let { return it }
+
+        var token = urlLock.tryAcquire(normalizedUrl, props.lockTtl)
         if (token == null) {
-            waitForCache(url)?.let { return it }
-            token = urlLock.tryAcquire(url, props.lockTtl)
-                ?: throw DownloadInProgressException(url)
+            waitForCache(normalizedUrl)?.let { return it }
+            token = urlLock.tryAcquire(normalizedUrl, props.lockTtl)
+                ?: throw DownloadInProgressException(normalizedUrl)
         }
 
         try {
-            getCachedOrNull(url, afterLock = true)?.let { return it }
-            val result = delegate.download(url)
+            getCachedOrNull(normalizedUrl, afterLock = true)?.let { return it }
+            val result = delegate.download(normalizedUrl)
             mediaCache.put(result, props.mediaTtl)
             return result
         } finally {
-            urlLock.release(url, token)
+            urlLock.release(normalizedUrl, token)
         }
     }
 

--- a/src/main/kotlin/com/download/downloaderbot/core/tools/AbstractCliTool.kt
+++ b/src/main/kotlin/com/download/downloaderbot/core/tools/AbstractCliTool.kt
@@ -1,6 +1,5 @@
 package com.download.downloaderbot.core.tools
 
-import com.download.downloaderbot.core.downloader.MediaDownloaderToolException
 import com.download.downloaderbot.core.downloader.ToolExecutionException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -53,7 +52,7 @@ abstract class AbstractCliTool(
     ) = try {
         val exitCode = awaitExitCode(process)
         readerJob.join()
-        handleExitCode(exitCode, url, output.toString())
+        handleExitCode(exitCode, output.toString())
     } catch (ce: CancellationException) {
         log.info { "Cancelling download process for $url" }
         if (process.isAlive) process.destroyForcibly()
@@ -74,9 +73,9 @@ abstract class AbstractCliTool(
         throw t
     }
 
-    private fun handleExitCode(exitCode: Int, url: String, output: String) {
+    private fun handleExitCode(exitCode: Int, output: String) {
         if (exitCode != 0)
-            throw ToolExecutionException(url, exitCode, output)
+            throw ToolExecutionException(bin, exitCode, output)
     }
 
     private fun buildCommand(url: String, args: List<String> = emptyList()): List<String> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,12 +32,11 @@ downloader:
       video: 50MB
   yt-dlp:
     enabled: true
+    format: 137+140/136+140/135+140/134+140/18
     bin: yt-dlp
-    extra-args:
   gallery-dl:
     enabled: false
     bin: gallery-dl
-    extra-args:
   cache:
     media-ttl: 7d
     lock-ttl: 60s

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,9 +30,14 @@ downloader:
     max-size:
       photo: 10MB
       video: 50MB
+  sources:
+    allow:
+      - ^https?://([a-z0-9-]+\.)?tiktok\.com/@[^/]+/video/\d+(?:/|(?:\?.*)?)?$
+      - ^https?://([a-z0-9-]+\.)?tiktok\.com/video/\d+(?:/|(?:\?.*)?)?$
+      - ^https?://(www\.|m\.)?youtube\.com/shorts/[A-Za-z0-9_-]{11}(?:\?.*)?$
   yt-dlp:
     enabled: true
-    format: 137+140/136+140/135+140/134+140/18
+    format: 137+140/136+140/135+140/134+140/18/b[ext=mp4]/b
     bin: yt-dlp
   gallery-dl:
     enabled: false


### PR DESCRIPTION
- add SourceAllowProperties (downloader.sources.allow)
- introduce UrlAllowlist (case-insensitive regex)
- check allowlist in CachedMediaDownloadService and throw UnsupportedSourceException
- seed allowlist with TikTok/YT Shorts patterns
- refine yt-dlp format to prefer mp4 with best fallback